### PR TITLE
Add version operators to external requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,12 @@
     "require": {
         "php": ">=5.4.0",
         "ext-fileinfo": "*",
-        "intervention/image": "*",
-        "mistic100/randomcolor": "*"
+        "intervention/image": "~2.3",
+        "mistic100/randomcolor": "~1.0"
     },
     "autoload": {
         "psr-4": {
             "Shift\\AvatarMaker\\": "src/Shift/AvatarMaker"
         }
     }
-
 }


### PR DESCRIPTION
This assumes that the external libraries use semantic versioning. See https://getcomposer.org/doc/articles/versions.md#next-significant-release-operators for details.
