### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+nbproject
+vendor
+composer.lock


### PR DESCRIPTION
A .gitignore file with rules to ignore generated (meta) data from NetBeans and Composer.
