### PR TITLE
Remove unnecessary require line from demo.

### DIFF
--- a/demo/demo.php
+++ b/demo/demo.php
@@ -4,7 +4,6 @@ ini_set('display_errors', 1);
 error_reporting(-1);
 
 require_once __DIR__ . '/../vendor/autoload.php';
-require_once '../temp/test-includes.php';
 
 // If you get "Could not find/open font" errors with the "gd" driver, try
 // setting this environment variable.


### PR DESCRIPTION
Demo doesn’t work out of the box when this line is present.